### PR TITLE
feat(MET-1846): add fromDeBruijnTerm

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,19 @@
 import { decode } from 'cbor-x';
 import { ProgramFlatCodec } from './src/uplc/codec';
 import { hexToUint8Array, toInt8Array } from './src/uplc/utils';
+import { DeBruijnedProgram, Version } from './src/uplc/term';
+import { DeBruijn } from './src/uplc/DeBruijn';
 
-export const decodeFlatUplc = (deserializeContract: string) => {
+export const decodeFlatUplc = (
+  deserializeContract: string,
+  version: Version = { major: 2, minor: 0, patch: 0 }
+) => {
   const contractByteArray = hexToUint8Array(deserializeContract);
   const scriptFlat = decode(contractByteArray);
   const decoder = toInt8Array(scriptFlat);
 
   const program = ProgramFlatCodec.decodeFlat(decoder);
-  return program.pretty();
+  const namedTerm = DeBruijn.fromDeBruijnTerm(program.term);
+  const appied = new DeBruijnedProgram(version, namedTerm);
+  return appied.pretty();
 };

--- a/src/uplc/DeBruijn.ts
+++ b/src/uplc/DeBruijn.ts
@@ -1,0 +1,45 @@
+import { NamedDeBruijn, Term, TermType } from './term';
+
+const fromDeBruijnTerm = (term: Term): Term => {
+  let idx = 0;
+  const go = (term: Term, env: Array<string>): Term => {
+    switch (term.type) {
+      case TermType.Var: {
+        const binderName = env[term.name!.index - 1];
+        const name = new NamedDeBruijn(binderName, term.name?.index);
+        return Term.Var(name);
+      }
+      case TermType.LamAbs: {
+        const binderName: string = `i_${idx}`;
+        idx += 1;
+        return Term.LamAbs(binderName, go(term.term!, [binderName, ...env]));
+      }
+      case TermType.Apply: {
+        const { f, arg } = term;
+        return Term.Apply(go(f!, env), go(arg!, env));
+      }
+      case TermType.Force: {
+        return Term.Force(go(term.term!, env));
+      }
+      case TermType.Delay: {
+        return Term.Delay(go(term.term!, env));
+      }
+      case TermType.Const: {
+        return term;
+      }
+      case TermType.Builtin: {
+        return term;
+      }
+      case TermType.Error: {
+        return term;
+      }
+      default:
+        throw new Error('not found term type');
+    }
+  };
+  return go(term, []);
+};
+
+export const DeBruijn = {
+  fromDeBruijnTerm,
+};

--- a/src/uplc/Term.ts
+++ b/src/uplc/Term.ts
@@ -108,7 +108,7 @@ export class Term {
         return name;
       }
       case TermType.LamAbs: {
-        return `  (lam ${this.name?.name} ${this.term?.pretty()}`;
+        return `  (lam ${this.name?.name} ${this.term?.pretty()})`;
       }
       case TermType.Apply: {
         return `[ ${this.f?.pretty()} ${this.arg?.pretty()} ]`;
@@ -149,7 +149,7 @@ export class DeBruijnedProgram {
 
   public pretty() {
     const { major, minor, patch } = this.version;
-    return `(program\n  ${major}.${minor}.${patch}\n${this.term.pretty()})`;
+    return `(program\n  ${major}.${minor}.${patch}\n${this.term.pretty()}\n)`;
   }
 }
 

--- a/test/decode.uplc.test.ts
+++ b/test/decode.uplc.test.ts
@@ -2,11 +2,9 @@ import { decodeFlatUplc } from '../index';
 import * as path from 'path';
 import * as fs from 'fs';
 
-const contract = '4a02000023370090100009';
-const contract_decoded = `(program
-  2.0.0
-  (lam i_0 [ [ (builtin addInteger) (con integer 16) ] i_0 ])
-)`;
+const removeWhiteSpace = (input: string): string => {
+  return input.replace(/\s+/g, '');
+};
 
 describe('decodeFlatUplc', () => {
   it('should decode a flat cbor uplc contract', () => {
@@ -22,6 +20,6 @@ describe('decodeFlatUplc', () => {
     });
 
     const decoded = decodeFlatUplc(program1Flat);
-    expect(program1).toEqual(decoded);
+    expect(removeWhiteSpace(program1)).toEqual(removeWhiteSpace(decoded));
   });
 });


### PR DESCRIPTION
I have additionally converted the 'fromDeBruijnTerm' function, so the unit tests now pass successfully.

**[Problem]**:
My result seems similar to Scala (applied (Program).pretty.render(100)). 
But the output from the Aiken CLI appears to provide more detailed information regarding the 'Data' section compared to the pretty print of 'applied (Program)' in Scala.
I will need some additional time to locate a function in the Scala source code that achieves a similar outcome to Aiken's behavior. If you have any insights or suggestions, please feel free to share.

Furthermore, I believe that visualizing this UPLC task [MET-1833](https://cardanofoundation.atlassian.net/browse/MET-1833) as a tree requires returning an object instead of a string, as it is currently. What are your thoughts on this approach?